### PR TITLE
Correct the HTTP url for cloning

### DIFF
--- a/index.t
+++ b/index.t
@@ -50,7 +50,7 @@ SUBTITLE(Download)
 
 <li> <a href="snapshots/">Daily snapshots</a>
 
-<li> <tt>git clone https://github.com:libssh2/libssh2.git</tt> <a href="https://github.com/libssh2/libssh2">browse the code repo</a>
+<li> <tt>git clone https://github.com/libssh2/libssh2.git</tt> <a href="https://github.com/libssh2/libssh2">browse the code repo</a>
 
 <li> <a href="download/">Older releases</a>
 


### PR DESCRIPTION
Replace a stray colon with a slash, presumably a left-over from an earlier SSH URL.