### PR TITLE
Correct note that libssh supports hostbased auth

### DIFF
--- a/libssh2-vs-libssh.t
+++ b/libssh2-vs-libssh.t
@@ -46,7 +46,7 @@ SUBTITLE(<a href="https://www.libssh.org/">libssh</a> 0.7.x)
     <li>Ciphers: aes256-ctr, aes192-ctr, aes128-ctr, aes256-cbc (rijndael-cbc@lysator.liu.se), aes192-cbc, aes128-cbc, 3des-cbc, blowfish-cbc, none
     <li>Compression Schemes: zlib, zlib@openssh.com, none
     <li>MAC hashes: hmac-sha1, none
-    <li>Authentication: none, password, public-key, hostbased, keyboard-interactive, gssapi-with-mic
+    <li>Authentication: none, password, public-key, keyboard-interactive, gssapi-with-mic
     <li>Channels: shell, exec (incl. SCP wrapper), direct-tcpip, subsystem, auth-agent-req@openssh.com
     <li>Global Requests: tcpip-forward, forwarded-tcpip
     <li>Channel Requests: x11, pty, exit-status, signal, exit-signal, keepalive@openssh.com, auth-agent-req@openssh.com


### PR DESCRIPTION
See https://www.libssh.org/features/ - hostbased authentication is not listed.