### PR TITLE
libssh2-vs-libssh.t: libssh still has non-blocking issues

### DIFF
--- a/libssh2-vs-libssh.t
+++ b/libssh2-vs-libssh.t
@@ -53,7 +53,7 @@ SUBTITLE(<a href="https://www.libssh.org/">libssh</a> 0.9.x)
     <li>Subsystems: sftp(version 3), OpenSSH Extensions
     <li>SFTP: statvfs@openssh.com, fstatvfs@openssh.com
     <li>Thread-safe: Just don't share sessions
-    <li>Non-blocking: it can be used both blocking and non-blocking
+    <li>Non-blocking: it can <b>not</b> be used entirely non-blocking.
     <li>Your sockets: the app hands over the socket, or uses libssh sockets
     <li>OpenSSL, mbedTLS or gcrypt
     <li>Client and server support


### PR DESCRIPTION
The libssh maintainers insisted many years ago that it works, but curl still seems problems in 2023 and there are pending merges in libssh to address blocking problems. libssh2 has been non-blocking since about 2007.